### PR TITLE
chore(deps): bump grafana apps versions

### DIFF
--- a/plugins.list
+++ b/plugins.list
@@ -4,7 +4,7 @@ simpod-json-datasource 0.6.7
 vertamedia-clickhouse-datasource 3.4.4
 victoriametrics-logs-datasource 0.19.3
 victoriametrics-metrics-datasource 0.18.3
-yesoreyeram-infinity-datasource 3.4.1
+yesoreyeram-infinity-datasource 3.5.0
 # ReactJS plugins
 aceiot-svg-panel 0.1.5
 briangann-gauge-panel 2.0.1
@@ -15,6 +15,6 @@ timomyl-breadcrumb-panel 1.2.0
 vonage-status-panel 2.0.4
 # Applications
 grafana-exploretraces-app 1.1.3
-grafana-lokiexplore-app 1.0.25
-grafana-oncall-app 1.16.4
-grafana-pyroscope-app 1.7.0
+grafana-lokiexplore-app 1.0.26
+grafana-oncall-app 1.16.5
+grafana-pyroscope-app 1.8.1


### PR DESCRIPTION
# What does this PR do?

Bump Grafana plugins and applications to the latest available versions.

Changes:

* yesoreyeram-infinity-datasource `3.4.1` -> `3.5.0`
* grafana-lokiexplore-app `1.0.25` -> `1.0.26`
* grafana-oncall-app `1.16.4` -> `1.16.5`
* grafana-pyroscope-app `1.7.0` -> `1.8.1`