### PR TITLE
chore(deps): remove grafana oncall plugin to avoid vulnerabilities in it

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ These plugins are downloaded while this image build instead of init container ru
   * [VictoriaMetrics](https://grafana.com/grafana/plugins/victoriametrics-metrics-datasource)
   * [VictoriaLogs](https://grafana.com/grafana/plugins/victoriametrics-logs-datasource)
 * Applications:
-  * [Grafana OnCall](https://grafana.com/grafana/plugins/grafana-oncall-app)
   * [Grafana Logs Drilldown](https://grafana.com/grafana/plugins/grafana-lokiexplore-app)
   * [Grafana Traces Drilldown](https://grafana.com/grafana/plugins/grafana-exploretraces-app)
   * [Grafana Profiles Drilldown](https://grafana.com/grafana/plugins/grafana-pyroscope-app)

--- a/plugins.list
+++ b/plugins.list
@@ -17,5 +17,4 @@ vonage-status-panel 2.0.4
 # Applications
 grafana-exploretraces-app 1.1.3
 grafana-lokiexplore-app 1.0.26
-grafana-oncall-app 1.16.5
 grafana-pyroscope-app 1.8.1


### PR DESCRIPTION
# What does this PR do?

In the Grafana OnCall plugin exists the vulnerability `CVE-2025-22871`.

Currently, this plugin is not being used, so it makes sense to remove it and avoid this vulnerability.